### PR TITLE
fix info user with no used vacation days

### DIFF
--- a/src/components/UserHoliday/index.js
+++ b/src/components/UserHoliday/index.js
@@ -12,10 +12,10 @@ function UserHoliday(props) {
     <div className='info-holidays'>
        Información sobre las vacaciones de este año de <span className="bold-name">{selectedUser.name}</span> :
       <ul className='info-holidays__days'>
-        <li>Vacaciones totales: {selectedUser.vacation_days[moment().year()] || 'sin información'}</li>
-        <li>Vacaciones usadas: {selectedUser.vacations_used[moment().year()] || 'sin información'}</li>
+        <li>Vacaciones totales: {selectedUser.vacation_days[moment().year()] || '0'}</li>
+        <li>Vacaciones usadas: {selectedUser.vacations_used[moment().year()] || '0'}</li>
         <li>
-          Vacaciones disponibles: {daysLeft || 'sin información'}
+          Vacaciones disponibles: {daysLeft || '0'}
         </li>
       </ul>
     </div>


### PR DESCRIPTION
Fix an error that printed "sin información" message when user used vacations days was equal to 0.

Please review this.